### PR TITLE
feat: Model Council — parallel multi-model queries with synthesis

### DIFF
--- a/src/perplexity_web_mcp/__init__.py
+++ b/src/perplexity_web_mcp/__init__.py
@@ -18,8 +18,9 @@ from .exceptions import (
 )
 from .models import Model, Models
 from .rate_limits import RateLimitCache, RateLimits, SourceLimit, UserSettings, fetch_rate_limits, fetch_user_settings
+from .council import CouncilMemberResult, CouncilResponse
 from .router import Intent, QuotaLevel, QuotaState, RoutingDecision, SmartResponse, SmartRouter
-from .shared import smart_ask
+from .shared import council_ask, smart_ask
 from .types import Coordinates, Response, SearchResultItem
 
 
@@ -34,6 +35,8 @@ __all__: list[str] = [
     "Conversation",
     "ConversationConfig",
     "Coordinates",
+    "CouncilMemberResult",
+    "CouncilResponse",
     "FileUploadError",
     "FileValidationError",
     "HTTPError",
@@ -61,6 +64,7 @@ __all__: list[str] = [
     "StreamingError",
     "TimeRange",
     "UserSettings",
+    "council_ask",
     "fetch_rate_limits",
     "fetch_user_settings",
     "smart_ask",

--- a/src/perplexity_web_mcp/council.py
+++ b/src/perplexity_web_mcp/council.py
@@ -1,0 +1,277 @@
+"""Model Council: query multiple models in parallel and synthesize results.
+
+Sends the same prompt to N models concurrently (via ThreadPoolExecutor),
+collects their responses, then optionally uses Sonar (free, no Pro quota)
+to produce a synthesized consensus that highlights agreements and
+disagreements between the models.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .config import ConversationConfig
+from .enums import CitationMode, SearchFocus, SourceFocus
+from .logging import get_logger
+from .models import Model, Models
+
+
+if TYPE_CHECKING:
+    from .types import SearchResultItem
+
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Default council composition
+# ---------------------------------------------------------------------------
+
+COUNCIL_DEFAULT_MODELS: list[tuple[str, Model]] = [
+    ("GPT-5.4", Models.GPT_54),
+    ("Claude Opus 4.6", Models.CLAUDE_46_OPUS),
+    ("Gemini 3.1 Pro", Models.GEMINI_31_PRO_THINKING),
+]
+"""Default models for the council (3 diverse providers)."""
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class CouncilMemberResult:
+    """Result from a single council member model."""
+
+    model_name: str
+    answer: str
+    search_results: list[SearchResultItem] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CouncilResponse:
+    """Full council response with individual results and synthesis."""
+
+    individual_results: list[CouncilMemberResult]
+    synthesis: str
+    query: str
+    model_names: list[str]
+
+    def format_response(self) -> str:
+        """Format the full council response for display."""
+        parts: list[str] = []
+
+        if self.synthesis:
+            parts.append("# 🏛️ Model Council — Synthesized Answer\n")
+            parts.append(self.synthesis)
+            parts.append("\n\n---\n")
+
+        parts.append("# Individual Model Responses\n")
+        for r in self.individual_results:
+            status = "✅" if r.error is None else "❌"
+            parts.append(f"## {status} {r.model_name}\n")
+            parts.append(r.answer)
+            if r.search_results:
+                parts.append("\n\n**Citations:**")
+                for i, sr in enumerate(r.search_results, 1):
+                    parts.append(f"\n[{i}]: {sr.url or ''}")
+            parts.append("\n\n")
+
+        return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Internal: query a single model
+# ---------------------------------------------------------------------------
+
+def _query_single_model(
+    model_name: str,
+    model: Model,
+    query: str,
+    sources: list[SourceFocus],
+    search_focus: SearchFocus,
+) -> CouncilMemberResult:
+    """Query a single model. Designed to run inside a thread pool."""
+    from .shared import get_client
+
+    try:
+        client = get_client()
+        conversation = client.create_conversation(
+            ConversationConfig(
+                model=model,
+                citation_mode=CitationMode.DEFAULT,
+                search_focus=search_focus,
+                source_focus=sources,
+            )
+        )
+        conversation.ask(query)
+
+        answer = conversation.answer or "No answer received"
+        return CouncilMemberResult(
+            model_name=model_name,
+            answer=answer,
+            search_results=list(conversation.search_results or []),
+        )
+    except Exception as exc:
+        logger.warning(f"Council member {model_name} failed: {exc}")
+        return CouncilMemberResult(
+            model_name=model_name,
+            answer=f"[Error querying {model_name}: {exc}]",
+            error=str(exc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal: synthesize results using Sonar (free)
+# ---------------------------------------------------------------------------
+
+_SYNTHESIS_SYSTEM_PROMPT = """\
+You are synthesizing answers from {n} AI models that all responded to the same question.
+Your job is to produce a single, authoritative answer by analyzing where the models agree \
+and disagree.
+
+## Original Question
+{query}
+
+{model_sections}
+
+## Your Task
+1. **SYNTHESIS** — Write the best unified answer, drawing on all models' strengths.
+2. **AGREEMENTS** — List key points where all models converge.
+3. **DISAGREEMENTS** — List points where models diverge, and briefly assess which \
+   position is more likely correct and why.
+
+Be concise but thorough. Use markdown formatting.\
+"""
+
+
+def _build_synthesis_prompt(
+    query: str, results: list[CouncilMemberResult],
+) -> str:
+    """Build the prompt for the synthesis model."""
+    sections: list[str] = []
+    for r in results:
+        if r.error is None:
+            sections.append(f"## {r.model_name}'s Answer\n{r.answer}")
+        else:
+            sections.append(f"## {r.model_name}\n[This model encountered an error and did not respond.]")
+
+    return _SYNTHESIS_SYSTEM_PROMPT.format(
+        n=len(results),
+        query=query,
+        model_sections="\n\n".join(sections),
+    )
+
+
+def _synthesize(
+    query: str,
+    results: list[CouncilMemberResult],
+    sources: list[SourceFocus],
+    search_focus: SearchFocus,
+) -> str:
+    """Synthesize council results using Sonar (free — no Pro quota cost)."""
+    synthesis_prompt = _build_synthesis_prompt(query, results)
+
+    try:
+        result = _query_single_model(
+            "Sonar (synthesizer)",
+            Models.SONAR,
+            synthesis_prompt,
+            sources,
+            search_focus,
+        )
+        return result.answer
+    except Exception as exc:
+        logger.warning(f"Synthesis failed: {exc}")
+        return "[Synthesis unavailable — individual model responses are shown below.]"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def council_ask(
+    query: str,
+    models: list[tuple[str, Model]] | None = None,
+    source_focus: str = "web",
+    synthesize: bool = True,
+) -> CouncilResponse:
+    """Query multiple models in parallel and optionally synthesize results.
+
+    Args:
+        query: The question to ask all models.
+        models: List of (display_name, Model) tuples. Defaults to
+                COUNCIL_DEFAULT_MODELS (GPT-5.4, Claude Opus, Gemini Pro).
+        source_focus: Source focus for all queries (none/web/academic/social/finance/all).
+        synthesize: Whether to produce a synthesized consensus (adds 1 free Sonar query).
+
+    Returns:
+        CouncilResponse with individual results and optional synthesis.
+    """
+    from .shared import SOURCE_FOCUS_MAP, check_limits_before_query
+
+    council = models or COUNCIL_DEFAULT_MODELS
+    sources = SOURCE_FOCUS_MAP.get(source_focus, [SourceFocus.WEB])
+    search_mode = SearchFocus.WRITING if source_focus == "none" else SearchFocus.WEB
+
+    # Pre-flight: check if we have enough Pro quota for N queries
+    for model_name, model in council:
+        limit_error = check_limits_before_query(model)
+        if limit_error:
+            return CouncilResponse(
+                individual_results=[
+                    CouncilMemberResult(
+                        model_name="Council",
+                        answer=limit_error,
+                        error="rate_limit",
+                    )
+                ],
+                synthesis="",
+                query=query,
+                model_names=[name for name, _ in council],
+            )
+
+    model_names = [name for name, _ in council]
+    logger.info(f"Council: querying {len(council)} models in parallel: {model_names}")
+
+    # Execute all queries in parallel
+    results: list[CouncilMemberResult] = []
+    with ThreadPoolExecutor(max_workers=len(council)) as executor:
+        future_to_name = {
+            executor.submit(
+                _query_single_model, name, model, query, sources, search_mode,
+            ): name
+            for name, model in council
+        }
+
+        for future in as_completed(future_to_name):
+            results.append(future.result())
+
+    # Sort results to match the original model order
+    name_order = {name: i for i, name in enumerate(model_names)}
+    results.sort(key=lambda r: name_order.get(r.model_name, len(model_names)))
+
+    # Synthesize if requested and we have successful results
+    synthesis = ""
+    successful = [r for r in results if r.error is None]
+    if synthesize and len(successful) >= 2:
+        synthesis = _synthesize(query, results, sources, search_mode)
+    elif synthesize and len(successful) < 2:
+        synthesis = "[Not enough successful responses to synthesize.]"
+
+    from .rate_limits import RateLimitCache
+    from .shared import get_limit_cache
+
+    cache = get_limit_cache()
+    if cache:
+        cache.invalidate_rate_limits()
+
+    return CouncilResponse(
+        individual_results=results,
+        synthesis=synthesis,
+        query=query,
+        model_names=model_names,
+    )

--- a/src/perplexity_web_mcp/mcp/server.py
+++ b/src/perplexity_web_mcp/mcp/server.py
@@ -189,6 +189,63 @@ def pplx_smart_query(
     return result.format_response()
 
 
+@mcp.tool
+def pplx_council(
+    query: str,
+    source_focus: SourceFocusName = "web",
+    models: str = "gpt54,claude_opus,gemini_pro",
+    synthesize: bool = True,
+) -> str:
+    """Model Council — query multiple models in parallel, get synthesized consensus.
+
+    COSTS 3 PRO SEARCH QUERIES (one per council member) + 1 Sonar (free) for synthesis.
+    Use when you need high-confidence answers validated across multiple AI providers.
+    Ideal for important decisions, fact-checking, and complex analysis.
+
+    Default council: GPT-5.4, Claude Opus 4.6, Gemini 3.1 Pro (3 diverse providers).
+
+    Args:
+        query: The question to ask all council models
+        source_focus: Source type for all models (none/web/academic/social/finance/all)
+        models: Comma-separated model names to use as council members.
+                Available: auto, sonar, gpt54, claude_sonnet, claude_opus, gemini_pro, nemotron.
+                Default: "gpt54,claude_opus,gemini_pro"
+        synthesize: Whether to synthesize a consensus from all responses.
+                    Set false to get only individual responses (saves 1 Sonar call).
+    """
+    from perplexity_web_mcp.council import COUNCIL_DEFAULT_MODELS
+
+    # Parse custom model list if provided
+    model_list = None
+    if models != "gpt54,claude_opus,gemini_pro":
+        model_list = []
+        for name in models.split(","):
+            name = name.strip()
+            resolved = resolve_model(name)
+            # Map short names to display names
+            display_names = {
+                "auto": "Auto (Best)",
+                "sonar": "Sonar",
+                "gpt54": "GPT-5.4",
+                "claude_sonnet": "Claude Sonnet 4.6",
+                "claude_opus": "Claude Opus 4.6",
+                "gemini_pro": "Gemini 3.1 Pro",
+                "nemotron": "Nemotron 3 Super",
+            }
+            display = display_names.get(name, name)
+            model_list.append((display, resolved))
+
+    from perplexity_web_mcp.shared import council_ask
+
+    result = council_ask(
+        query=query,
+        models=model_list,
+        source_focus=source_focus,
+        synthesize=synthesize,
+    )
+    return result.format_response()
+
+
 # =============================================================================
 # Usage & Limits Tools
 # =============================================================================

--- a/src/perplexity_web_mcp/shared.py
+++ b/src/perplexity_web_mcp/shared.py
@@ -426,3 +426,39 @@ def smart_ask(
 
     citations = [r.url or "" for r in search_results]
     return SmartResponse(answer=answer, citations=citations, routing=decision)
+
+
+# ---------------------------------------------------------------------------
+# Council ask (multi-model parallel query with synthesis)
+# ---------------------------------------------------------------------------
+
+def council_ask(
+    query: str,
+    models: list[tuple[str, Model]] | None = None,
+    source_focus: SourceFocusName = "web",
+    synthesize: bool = True,
+) -> "CouncilResponse":
+    """Query multiple models in parallel and optionally synthesize results.
+
+    Each council member model is queried concurrently. A free Sonar query
+    then synthesizes the responses into a consensus answer highlighting
+    agreements and disagreements.
+
+    Args:
+        query: The question to ask all models.
+        models: List of (display_name, Model) tuples. Defaults to
+                GPT-5.4, Claude Opus 4.6, and Gemini 3.1 Pro.
+        source_focus: Source focus for all queries.
+        synthesize: Whether to run Sonar synthesis (free, no Pro cost).
+
+    Returns:
+        CouncilResponse with individual results and optional synthesis.
+    """
+    from .council import CouncilResponse, council_ask as _council_ask
+
+    return _council_ask(
+        query=query,
+        models=models,
+        source_focus=source_focus,
+        synthesize=synthesize,
+    )

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -1,0 +1,376 @@
+"""Tests for the council module (Model Council: parallel multi-model queries)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from perplexity_web_mcp.council import (
+    COUNCIL_DEFAULT_MODELS,
+    CouncilMemberResult,
+    CouncilResponse,
+    _build_synthesis_prompt,
+    council_ask,
+)
+from perplexity_web_mcp.models import Model, Models
+
+
+# ============================================================================
+# 1. Data classes
+# ============================================================================
+
+
+class TestCouncilMemberResult:
+    """Verify CouncilMemberResult dataclass behavior."""
+
+    def test_successful_result(self) -> None:
+        result = CouncilMemberResult(model_name="GPT-5.4", answer="The answer is 42")
+        assert result.model_name == "GPT-5.4"
+        assert result.answer == "The answer is 42"
+        assert result.error is None
+        assert result.search_results == []
+
+    def test_error_result(self) -> None:
+        result = CouncilMemberResult(
+            model_name="Claude", answer="[Error]", error="Network failure"
+        )
+        assert result.error == "Network failure"
+
+    def test_is_frozen(self) -> None:
+        result = CouncilMemberResult(model_name="Test", answer="Test")
+        with pytest.raises(AttributeError):
+            result.model_name = "Changed"  # type: ignore[misc]
+
+
+class TestCouncilResponse:
+    """Verify CouncilResponse dataclass and formatting."""
+
+    def test_format_response_with_synthesis(self) -> None:
+        results = [
+            CouncilMemberResult(model_name="GPT-5.4", answer="Answer A"),
+            CouncilMemberResult(model_name="Claude", answer="Answer B"),
+        ]
+        response = CouncilResponse(
+            individual_results=results,
+            synthesis="Combined answer",
+            query="test question",
+            model_names=["GPT-5.4", "Claude"],
+        )
+        formatted = response.format_response()
+        assert "Model Council" in formatted
+        assert "Synthesized" in formatted
+        assert "Combined answer" in formatted
+        assert "GPT-5.4" in formatted
+        assert "Claude" in formatted
+        assert "Answer A" in formatted
+        assert "Answer B" in formatted
+
+    def test_format_response_without_synthesis(self) -> None:
+        results = [
+            CouncilMemberResult(model_name="GPT-5.4", answer="Answer A"),
+        ]
+        response = CouncilResponse(
+            individual_results=results,
+            synthesis="",
+            query="test question",
+            model_names=["GPT-5.4"],
+        )
+        formatted = response.format_response()
+        assert "Synthesized" not in formatted
+        assert "GPT-5.4" in formatted
+
+    def test_format_response_marks_errors(self) -> None:
+        results = [
+            CouncilMemberResult(model_name="GPT-5.4", answer="OK"),
+            CouncilMemberResult(
+                model_name="Claude", answer="[Error]", error="timeout"
+            ),
+        ]
+        response = CouncilResponse(
+            individual_results=results,
+            synthesis="",
+            query="test",
+            model_names=["GPT-5.4", "Claude"],
+        )
+        formatted = response.format_response()
+        assert "✅" in formatted
+        assert "❌" in formatted
+
+
+# ============================================================================
+# 2. Default models
+# ============================================================================
+
+
+class TestDefaultModels:
+    """Verify the default council composition."""
+
+    def test_default_models_has_three_members(self) -> None:
+        assert len(COUNCIL_DEFAULT_MODELS) == 3
+
+    def test_default_models_are_diverse_providers(self) -> None:
+        names = [name for name, _ in COUNCIL_DEFAULT_MODELS]
+        # Should have GPT, Claude, and Gemini for provider diversity
+        assert any("GPT" in n for n in names)
+        assert any("Claude" in n for n in names)
+        assert any("Gemini" in n for n in names)
+
+    def test_default_models_are_valid_model_instances(self) -> None:
+        for name, model in COUNCIL_DEFAULT_MODELS:
+            assert isinstance(model, Model), f"{name} is not a Model"
+
+
+# ============================================================================
+# 3. Synthesis prompt building
+# ============================================================================
+
+
+class TestBuildSynthesisPrompt:
+    """Verify synthesis prompt construction."""
+
+    def test_includes_original_question(self) -> None:
+        results = [
+            CouncilMemberResult(model_name="M1", answer="Answer 1"),
+        ]
+        prompt = _build_synthesis_prompt("What is 2+2?", results)
+        assert "What is 2+2?" in prompt
+
+    def test_includes_all_model_answers(self) -> None:
+        results = [
+            CouncilMemberResult(model_name="GPT", answer="Answer from GPT"),
+            CouncilMemberResult(model_name="Claude", answer="Answer from Claude"),
+        ]
+        prompt = _build_synthesis_prompt("test", results)
+        assert "GPT's Answer" in prompt
+        assert "Answer from GPT" in prompt
+        assert "Claude's Answer" in prompt
+        assert "Answer from Claude" in prompt
+
+    def test_handles_errored_models(self) -> None:
+        results = [
+            CouncilMemberResult(model_name="GPT", answer="OK"),
+            CouncilMemberResult(model_name="Claude", answer="[Error]", error="timeout"),
+        ]
+        prompt = _build_synthesis_prompt("test", results)
+        assert "GPT's Answer" in prompt
+        assert "did not respond" in prompt
+
+    def test_includes_synthesis_instructions(self) -> None:
+        results = [
+            CouncilMemberResult(model_name="M1", answer="A1"),
+        ]
+        prompt = _build_synthesis_prompt("test", results)
+        assert "SYNTHESIS" in prompt
+        assert "AGREEMENTS" in prompt
+        assert "DISAGREEMENTS" in prompt
+
+
+# ============================================================================
+# 4. council_ask function (mocked)
+# ============================================================================
+
+# NOTE: _query_single_model uses a local import `from .shared import get_client`,
+# so we mock at the shared module level where it's actually resolved.
+
+
+class TestCouncilAsk:
+    """Test the council_ask() function with mocked Perplexity client."""
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_queries_all_models_in_parallel(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        mock_conv = MagicMock()
+        mock_conv.answer = "Test answer"
+        mock_conv.search_results = []
+        mock_client = MagicMock()
+        mock_client.create_conversation.return_value = mock_conv
+        mock_client_fn.return_value = mock_client
+
+        result = council_ask("test question", synthesize=False)
+
+        assert isinstance(result, CouncilResponse)
+        # Default: 3 council models
+        assert len(result.individual_results) == 3
+        assert all(r.answer == "Test answer" for r in result.individual_results)
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_custom_models(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        mock_conv = MagicMock()
+        mock_conv.answer = "Custom answer"
+        mock_conv.search_results = []
+        mock_client = MagicMock()
+        mock_client.create_conversation.return_value = mock_conv
+        mock_client_fn.return_value = mock_client
+
+        custom = [
+            ("Sonar", Models.SONAR),
+            ("GPT", Models.GPT_54),
+        ]
+        result = council_ask("test", models=custom, synthesize=False)
+
+        assert len(result.individual_results) == 2
+        assert result.model_names == ["Sonar", "GPT"]
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_synthesis_runs_when_enabled(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        mock_conv = MagicMock()
+        mock_conv.answer = "Model answer"
+        mock_conv.search_results = []
+        mock_client = MagicMock()
+        mock_client.create_conversation.return_value = mock_conv
+        mock_client_fn.return_value = mock_client
+
+        result = council_ask("test question", synthesize=True)
+
+        assert isinstance(result, CouncilResponse)
+        # Synthesis should have produced something (Sonar was also mocked)
+        assert result.synthesis != ""
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_no_synthesis_when_disabled(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        mock_conv = MagicMock()
+        mock_conv.answer = "Answer"
+        mock_conv.search_results = []
+        mock_client = MagicMock()
+        mock_client.create_conversation.return_value = mock_conv
+        mock_client_fn.return_value = mock_client
+
+        result = council_ask("test", synthesize=False)
+        assert result.synthesis == ""
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query")
+    def test_rate_limit_returns_error_response(
+        self, mock_limits: MagicMock,
+    ) -> None:
+        mock_limits.return_value = "LIMIT REACHED: Pro Search exhausted"
+
+        result = council_ask("test")
+        assert len(result.individual_results) == 1
+        assert "LIMIT REACHED" in result.individual_results[0].answer
+        assert result.individual_results[0].error == "rate_limit"
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_partial_failure_still_returns_results(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        """If one model fails, others should still return successfully."""
+        call_count = 0
+
+        def create_conv_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_conv = MagicMock()
+            if call_count == 2:
+                mock_conv.ask.side_effect = RuntimeError("Model 2 failed")
+            else:
+                mock_conv.answer = f"Answer {call_count}"
+                mock_conv.search_results = []
+            return mock_conv
+
+        mock_client = MagicMock()
+        mock_client.create_conversation.side_effect = create_conv_side_effect
+        mock_client_fn.return_value = mock_client
+
+        result = council_ask("test", synthesize=False)
+
+        assert len(result.individual_results) == 3
+        errors = [r for r in result.individual_results if r.error is not None]
+        successes = [r for r in result.individual_results if r.error is None]
+        # At least some should succeed, at least one should fail
+        assert len(successes) >= 1
+        assert len(errors) >= 1
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_insufficient_successes_skips_synthesis(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        """Synthesis requires at least 2 successful responses."""
+        mock_client = MagicMock()
+
+        call_count = 0
+
+        def create_conv_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_conv = MagicMock()
+            if call_count <= 2:
+                mock_conv.ask.side_effect = RuntimeError("Failed")
+            else:
+                mock_conv.answer = "Only success"
+                mock_conv.search_results = []
+            return mock_conv
+
+        mock_client.create_conversation.side_effect = create_conv_side_effect
+        mock_client_fn.return_value = mock_client
+
+        result = council_ask("test", synthesize=True)
+        assert "Not enough successful" in result.synthesis
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_preserves_original_model_order(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        """Results should be sorted to match the original model order."""
+        mock_conv = MagicMock()
+        mock_conv.answer = "Answer"
+        mock_conv.search_results = []
+        mock_client = MagicMock()
+        mock_client.create_conversation.return_value = mock_conv
+        mock_client_fn.return_value = mock_client
+
+        result = council_ask("test", synthesize=False)
+
+        # Results should be in the same order as COUNCIL_DEFAULT_MODELS
+        expected_names = [name for name, _ in COUNCIL_DEFAULT_MODELS]
+        actual_names = [r.model_name for r in result.individual_results]
+        assert actual_names == expected_names
+
+
+# ============================================================================
+# 5. Shared council_ask wrapper
+# ============================================================================
+
+
+class TestSharedCouncilAsk:
+    """Test the council_ask wrapper in shared.py delegates correctly."""
+
+    @patch("perplexity_web_mcp.shared.check_limits_before_query", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_limit_cache", return_value=None)
+    @patch("perplexity_web_mcp.shared.get_client")
+    def test_shared_wrapper_delegates(
+        self, mock_client_fn: MagicMock, mock_cache: MagicMock, mock_limits: MagicMock,
+    ) -> None:
+        from perplexity_web_mcp.shared import council_ask as shared_council_ask
+
+        mock_conv = MagicMock()
+        mock_conv.answer = "Wrapper test"
+        mock_conv.search_results = []
+        mock_client = MagicMock()
+        mock_client.create_conversation.return_value = mock_conv
+        mock_client_fn.return_value = mock_client
+
+        result = shared_council_ask("test", synthesize=False)
+        assert isinstance(result, CouncilResponse)
+        assert len(result.individual_results) == 3


### PR DESCRIPTION
## Summary

Adds a new **`pplx_council`** MCP tool that implements Perplexity's Model Council concept: querying multiple AI models in parallel and synthesizing their responses into a unified consensus.

## What it does

1. **Parallel Execution** — Sends the same query to 3 models concurrently (GPT-5.4, Claude Opus 4.6, Gemini 3.1 Pro by default)
2. **Synthesis** — Feeds all responses to Sonar (free, no Pro quota cost) to produce a consensus that highlights agreements and disagreements
3. **Customizable** — Models can be customized via comma-separated names
4. **Graceful Degradation** — If one model fails, the others still return results

## Cost

- **3 Pro Search queries** (one per council member)
- **1 Sonar query** for synthesis (free, no Pro quota cost)
- Total: **3 Pro queries per council call**

## MCP Tool

```
pplx_council(
    query: str,
    source_focus: str = "web",
    models: str = "gpt54,claude_opus,gemini_pro",
    synthesize: bool = True,
) -> str
```

## Files Changed

| File | Change |
|------|--------|
| `src/perplexity_web_mcp/council.py` | **New** — Core council logic (parallel execution, synthesis, data classes) |
| `src/perplexity_web_mcp/mcp/server.py` | Add `pplx_council` tool |
| `src/perplexity_web_mcp/shared.py` | Add `council_ask()` wrapper |
| `src/perplexity_web_mcp/__init__.py` | Export `CouncilMemberResult`, `CouncilResponse`, `council_ask` |
| `tests/test_council.py` | **New** — 22 tests covering all paths |

## Tests

- **22 new tests** all passing
- **363 existing tests** still passing (0 regressions)
- Covers: data classes, default models, synthesis prompt, parallel execution, error handling, rate limits, ordering, and shared module wrapper